### PR TITLE
Refactor: modify kafka config

### DIFF
--- a/module-consumer/src/main/java/com/example/moduleconsumer/common/config/CouponConsumerConfiguration.java
+++ b/module-consumer/src/main/java/com/example/moduleconsumer/common/config/CouponConsumerConfiguration.java
@@ -27,6 +27,7 @@ public class CouponConsumerConfiguration {
         configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         configs.put(ConsumerConfig.GROUP_ID_CONFIG, "create_coupon");
         configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.LATEST.toString().toLowerCase());
+        configs.put(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG, -1);
         return new DefaultKafkaConsumerFactory<>(
                 configs,
                 new StringDeserializer(),

--- a/module-consumer/src/main/java/com/example/moduleconsumer/common/config/MemberConsumerConfiguration.java
+++ b/module-consumer/src/main/java/com/example/moduleconsumer/common/config/MemberConsumerConfiguration.java
@@ -33,6 +33,7 @@ public class MemberConsumerConfiguration {
         configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         configs.put(ConsumerConfig.GROUP_ID_CONFIG, "create_member");
         configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.LATEST.toString().toLowerCase());
+        configs.put(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG, -1);
         return new DefaultKafkaConsumerFactory<>(
                 configs,
                 new StringDeserializer(),

--- a/module-producer/src/main/java/com/example/moduleproducer/common/config/CouponProducerConfiguration.java
+++ b/module-producer/src/main/java/com/example/moduleproducer/common/config/CouponProducerConfiguration.java
@@ -28,6 +28,7 @@ public class CouponProducerConfiguration {
         configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
         configs.put(ProducerConfig.BATCH_SIZE_CONFIG, 32 * 1024);
         configs.put(ProducerConfig.LINGER_MS_CONFIG, 20);
+        configs.put(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG, -1);
         return new DefaultKafkaProducerFactory<>(configs);
     }
 

--- a/module-producer/src/main/java/com/example/moduleproducer/common/config/MemberProducerConfiguration.java
+++ b/module-producer/src/main/java/com/example/moduleproducer/common/config/MemberProducerConfiguration.java
@@ -36,6 +36,7 @@ public class MemberProducerConfiguration {
         configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, false);
         configs.put(ProducerConfig.BATCH_SIZE_CONFIG, 32 * 1024);
         configs.put(ProducerConfig.LINGER_MS_CONFIG, 20);
+        configs.put(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG, -1);
         return new DefaultKafkaProducerFactory<>(configs);
     }
 


### PR DESCRIPTION
카프카 connection max idle ms 값을 음수로 설정하여 유휴 상태가 되도 커넥션이 유지되도록 설정 함.

### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 카프카 프로듀서와 컨슈머의 유휴 상태가 9분 이상 지속 시 브로커와 커넥션이 끊김

**TO-BE**
- 카프카 프로듀서와 컨슈머의 유휴 상태가 되더라도 브로커와 커넥션이 끊기지 않게 설정 값 변경
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 